### PR TITLE
feat: apache tomcat module

### DIFF
--- a/modules/logs/input-templates.d/linux-tomcat.yml
+++ b/modules/logs/input-templates.d/linux-tomcat.yml
@@ -26,7 +26,6 @@ vars:
 - type: filestream # This collects catalina logs
   id: tomcat_catalina_default
   paths: {{{MORIO_TOMCAT_CATALINA_LOGS_PATHS}}}
-  buffer_size: 100MB # This avoids breaking multiline events because of a buffer overflow
 
   parsers:
     - multiline:

--- a/modules/logs/input-templates.d/linux-tomcat.yml
+++ b/modules/logs/input-templates.d/linux-tomcat.yml
@@ -5,8 +5,8 @@ about: |-
   This collects access and error log data from the Apache Tomcat package.
   It autodetects and supports the following log file types and formats:
 
-  - access: access log file, using the default logging pattern
-  - catalina: global log file for server admin operations, usig the default logging pattern
+  - access: access log files using the default Tomcat single line logging pattern
+  - catalina: operations log files using the default Catalina multiline logging pattern
 
 vars:
   defaults:

--- a/modules/logs/input-templates.d/linux-tomcat.yml
+++ b/modules/logs/input-templates.d/linux-tomcat.yml
@@ -39,10 +39,7 @@ vars:
         target: morio
         fields:
           module: {{MORIO_MODULE_NAME}}
-    - add_fields:
-        target: morio
-        fields:
-          module_version: "TC-AB"
+          module_version: "TC-AC"
     - add_fields:
         target: host
         fields:
@@ -51,7 +48,7 @@ vars:
 
     - dissect:
         field: "message"
-        tokenizer: "%{+temp_timestamp} %{+temp_timestamp} %{log.level} [%{http.thread}] %{log.logger} %{event.message}"
+        tokenizer: "%{+timestamp} %{+timestamp} %{log.level} [%{http.thread}] %{log.logger} %{event.message}"
         target_prefix: ''
         ignore_missing: true
         ignore_failure: true
@@ -62,12 +59,10 @@ vars:
           detected_format: "catalina_default"
 
     - timestamp:
-        field: temp_timestamp
+        field: timestamp
         layouts:
           - '02-Jan-2006 15:04:05.999'
         timezone: Local
-    - drop_fields:
-        fields: temp_timestamp
 
 
 - type: filestream # This collects access logs
@@ -82,7 +77,7 @@ vars:
     - add_fields:
         target: morio
         fields:
-          module_version: "TA-AA"
+          module_version: "TA-AC"
     - add_fields:
         target: host
         fields:
@@ -96,7 +91,7 @@ vars:
       then:
         - dissect:
             field: "message"
-            tokenizer: "[%{temp_timestamp}] %{http.username} %{http.thread} %{source.ip} %{http.request.method} %{url.full} %{http.version} %{http.response.status_code} %{http.response.time} %{http.response.body.bytes} %{http.request.referrer} %{user_agent.original}"
+            tokenizer: "[%{timestamp}] %{http.username} %{http.thread} %{source.ip} %{http.request.method} %{url.full} %{http.version} %{http.response.status_code} %{http.response.time} %{http.response.body.bytes} %{http.request.referrer} %{user_agent.original}"
             target_prefix: ''
             ignore_missing: true
             ignore_failure: true
@@ -107,11 +102,9 @@ vars:
               detected_format: "access_default"
 
     - timestamp:
-        field: temp_timestamp
+        field: timestamp
         layouts:
           - '02/Jan/2006:15:04:05 -0700'
-    - drop_fields:
-        fields: temp_timestamp
 
     {{#MORIO_TOMCAT_SPLUNK_INDEX_NAME}}
     - add_fields:

--- a/modules/logs/input-templates.d/linux-tomcat.yml
+++ b/modules/logs/input-templates.d/linux-tomcat.yml
@@ -1,0 +1,125 @@
+{{#MORIO_DOCS}}
+about: |-
+  A filebeat module for Linux systems
+
+  This collects access and error log data from the Apache Tomcat package.
+  It autodetects and supports the following log file types and formats:
+
+  - access: access log file, using the default logging pattern
+  - catalina: global log file for server admin operations, usig the default logging pattern
+
+vars:
+  defaults:
+    MORIO_TOMCAT_ACCESS_LOGS_PATHS: "['/usr/local/tomcat/logs/*access*.log']"
+    MORIO_TOMCAT_CATALINA_LOGS_PATHS: "['/usr/local/tomcat/logs/catalina*.log']"
+    MORIO_TOMCAT_SPLUNK_INDEX_NAME: false
+  local:
+    MORIO_TOMCAT_ACCESS_LOGS_PATHS: A (glob) list of paths from which to collect Apache Tomcat access logs
+    MORIO_TOMCAT_CATALINA_LOGS_PATHS: A (glob) list of paths from which to collect Apache Tomcat catalina logs
+    MORIO_TOMCAT_SPLUNK_INDEX_NAME: If the logs are to be sent to a Splunk ecosystem, you can set this Morio variable to add a `splunk.index` field to the data, with the value of the variable.
+
+{{/MORIO_DOCS}}
+
+{{^MORIO_DOCS}}
+
+
+- type: filestream # This collects catalina logs
+  id: tomcat_catalina_default
+  paths: {{{MORIO_TOMCAT_CATALINA_LOGS_PATHS}}}
+  buffer_size: 100MB # This avoids breaking multiline events because of a buffer overflow
+
+  parsers:
+    - multiline:
+        type: pattern
+        pattern: '^\d{2}-[a-zA-Z]{3}-\d{4}'
+        negate: true
+        match: after
+
+  processors:
+    - add_fields:
+        target: morio
+        fields:
+          module: {{MORIO_MODULE_NAME}}
+    - add_fields:
+        target: morio
+        fields:
+          module_version: "TC-AB"
+    - add_fields:
+        target: host
+        fields:
+          id: {{MORIO_CLIENT_UUID}}
+    - add_id: null
+
+    - dissect:
+        field: "message"
+        tokenizer: "%{+temp_timestamp} %{+temp_timestamp} %{log.level} [%{http.thread}] %{log.logger} %{event.message}"
+        target_prefix: ''
+        ignore_missing: true
+        ignore_failure: true
+        overwrite_keys: true
+    - add_fields:
+        target: log
+        fields:
+          detected_format: "catalina_default"
+
+    - timestamp:
+        field: temp_timestamp
+        layouts:
+          - '02-Jan-2006 15:04:05.999'
+        timezone: Local
+    - drop_fields:
+        fields: temp_timestamp
+
+
+- type: filestream # This collects access logs
+  id: tomcat_access_default
+  paths: {{{MORIO_TOMCAT_ACCESS_LOGS_PATHS}}}
+
+  processors:
+    - add_fields:
+        target: morio
+        fields:
+          module: {{MORIO_MODULE_NAME}}
+    - add_fields:
+        target: morio
+        fields:
+          module_version: "TA-AA"
+    - add_fields:
+        target: host
+        fields:
+          id: {{MORIO_CLIENT_UUID}}
+    - add_id: null
+
+
+    - if:
+        regexp:
+            message: '^\[\d{2}\/[a-zA-Z]{3}\/\d{4}:\d{2}:\d{2}:\d{2}\s.\d{4}\]\s' # access log valve default logging pattern
+      then:
+        - dissect:
+            field: "message"
+            tokenizer: "[%{temp_timestamp}] %{http.username} %{http.thread} %{source.ip} %{http.request.method} %{url.full} %{http.version} %{http.response.status_code} %{http.response.time} %{http.response.body.bytes} %{http.request.referrer} %{user_agent.original}"
+            target_prefix: ''
+            ignore_missing: true
+            ignore_failure: true
+            overwrite_keys: true
+        - add_fields:
+            target: log
+            fields:
+              detected_format: "access_default"
+
+    - timestamp:
+        field: temp_timestamp
+        layouts:
+          - '02/Jan/2006:15:04:05 -0700'
+    - drop_fields:
+        fields: temp_timestamp
+
+    {{#MORIO_TOMCAT_SPLUNK_INDEX_NAME}}
+    - add_fields:
+        target: splunk
+        fields:
+          index: {{MORIO_TOMCAT_SPLUNK_INDEX_NAME}}
+    {{/MORIO_TOMCAT_SPLUNK_INDEX_NAME}}
+
+{{/MORIO_DOCS}}
+

--- a/modules/logs/module-templates.d/linux-tomcat.yml
+++ b/modules/logs/module-templates.d/linux-tomcat.yml
@@ -1,0 +1,5 @@
+# noop
+#
+# Filebeat does not list inputs as modules.
+# So we keep an empty file here to make sure this shows up as a Filebeat module.
+#


### PR DESCRIPTION
  This module collects access and error log data from the Apache Tomcat package.
  It autodetects and supports the following log file types and formats:

  - access: access log files using the default Tomcat single line logging pattern
  - catalina: operations log files using the default Catalina multiline logging pattern